### PR TITLE
alteração dos controllers para exibir imagens e de rotas

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -34,12 +34,33 @@ class Product extends Model
         parent::boot();
 
         static::creating(function ($product) {
-            $product->slug = Str::slug($product->name);
+            $baseSlug = Str::slug($product->name);
+            $uniqueSlug = $baseSlug;
+            $count = 1;
+
+            while (Product::where('slug', $uniqueSlug)->exists()) {
+                $uniqueSlug = "{$baseSlug}-{$count}";
+                $count++;
+            }
+
+            $product->slug = $uniqueSlug;
         });
 
         static::updating(function ($product) {
             if ($product->isDirty('name')) {
-                $product->slug = Str::slug($product->name);
+                $baseSlug = Str::slug($product->name);
+                $uniqueSlug = $baseSlug;
+                $count = 1;
+
+                while (Product::where('slug', $uniqueSlug)
+                    ->where('id', '!=', $product->id)
+                    ->exists()
+                ) {
+                    $uniqueSlug = "{$baseSlug}-{$count}";
+                    $count++;
+                }
+
+                $product->slug = $uniqueSlug;
             }
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,7 +31,7 @@ Route::get('/categories/{id}/products', [CategoryController::class, 'getCategory
 
 // Produtos
 Route::get('/products', [ProductController::class, 'index']);
-Route::get('/products/{product}', [ProductController::class, 'show']);
+Route::get('/products/{slug}', [ProductController::class, 'showBySlug']);
 
 // Imagens
 Route::get('/product-images', [ProductImageController::class, 'index']);
@@ -53,6 +53,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('products', ProductController::class)->except(['index', 'show']);
     Route::apiResource('categories', CategoryController::class)->except(['index', 'show']);
     Route::apiResource('product-images', ProductImageController::class)->except(['index', 'show']);
+    Route::post('/products/{product}/images', [ProductImageController::class, 'storeImages']);
     Route::apiResource('reviews', ReviewController::class)->except(['index', 'show']);
 
     Route::apiResource('cart', CartController::class);


### PR DESCRIPTION
O que foi feito:
Alteração dos métodos no ProductImageController de forma que exibisse de forma correta as imagens tanto nos Cards como na página de detalhes do produto.

Como testar:
cadastre um produto com imagem e procure pelo seu Card na página de categorias ao qual ele foi assimilado, depois abra o link do produto para verificar o retorno da imagem cadastrada na página.