### PR TITLE
Implementa imagens predefinidas aos dados populados atraves do migrate

### DIFF
--- a/app/Http/Controllers/ProductImageController.php
+++ b/app/Http/Controllers/ProductImageController.php
@@ -41,11 +41,11 @@ class ProductImageController extends Controller
         return response()->json($productImage, 201);
     }
 
-    public function show($slug)
-    {
-        // Já deve estar incluindo o relacionamento
-        return Product::with('images')->where('slug', $slug)->firstOrFail();
-    }
+    public function show(ProductImage $productImage)
+{
+    return $productImage->load('product');
+}
+
 
     public function update(UpdateProductImageRequest $request, ProductImage $productImage)
     {

--- a/database/factories/ProductImageFactory.php
+++ b/database/factories/ProductImageFactory.php
@@ -7,11 +7,31 @@ use App\Models\Product;
 
 class ProductImageFactory extends Factory
 {
+    // Lista das suas 10 imagens
+    protected $localImages = [
+        'produto00.jpeg',
+        'produto01.webp', 
+        'produto02.webp',
+        'produto03.jpeg',
+        'produto04.jpeg',
+        'produto05.jpeg',
+        'produto06.jpeg',
+        'produto07.jpeg',
+        'produto08.jpeg',
+        'produto09.jpeg',
+    ];
+
     public function definition(): array
     {
+        // Escolhe uma imagem aleatória da lista
+        $randomImage = $this->faker->randomElement($this->localImages);
+
+        // ✅ Use a URL do servidor Laravel (127.0.0.1:8000)
+        $imageUrl = 'http://127.0.0.1:8000/storage/product_images/' . $randomImage;
+        
         return [
-            'product_id' => Product::inRandomOrder()->first()->id,
-            'image_url' => fake()->imageUrl(640, 480, 'products', true),
+            'product_id' => 1, // Será sobrescrito pelo seeder
+            'image_url' => $imageUrl,
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -81,16 +81,20 @@ class DatabaseSeeder extends Seeder
         // 🔹 Criar Reviews fake
         Review::factory()->count(200)->create();
 
-        // Adicionar Imagens a produtos
-        foreach (Product::all() as $product) {
-            // Uma imagem principal e 2 extras
+        // 🔹 Adicionar Imagens a produtos - CORRIGIDO
+        $products = Product::all();
+        foreach ($products as $product) {
+            // Uma imagem principal para cada produto
             ProductImage::factory()->create([
-                'product_id' => $product->id,
+                'product_id' => $product->id, // Fixo para este produto
             ]);
 
-            ProductImage::factory()->count(2)->create([
-                'product_id' => $product->id,
-            ]);
+            // 0 a 2 imagens extras para alguns produtos
+            if (rand(0, 1)) { // 50% de chance de ter imagens extras
+                ProductImage::factory()->count(rand(1, 2))->create([
+                    'product_id' => $product->id, // Fixo para este produto
+                ]);
+            }
         }
 
         // 🔹 Criar Pedidos + Itens + Pagamentos
@@ -131,8 +135,6 @@ class DatabaseSeeder extends Seeder
                     'transaction_id' => fake()->uuid(),
                 ]);
             }
-
-            
         }
     }
 }


### PR DESCRIPTION
O que foi feito:
-Mudanças nas migrations com o intuito de assimilar imagens predefinidas aos anúncios gerados por suas factorys, para que a exibição do site ficasse mais similar com um ambiente real.

Como testar:
-Rode 'php artisan migrate:fresh --seed' e aguarde a página home carregar os cards para comprovar o retorno das imagens.